### PR TITLE
Bug Fix - <a> tags with no title attribute

### DIFF
--- a/src/HtmlToMarkdown.Net.Tests/HtmlToMarkdownTests.cs
+++ b/src/HtmlToMarkdown.Net.Tests/HtmlToMarkdownTests.cs
@@ -352,6 +352,15 @@ namespace HtmlToMarkdown.Net.Tests
             Assert.Equal(expected, _inlineConverter.Convert(html));
         }
 
+				[Fact]
+				public void Should_convert_links_that_have_no_title_attribute_inline()
+				{
+					var html = "<a href=\"http://www.example.com\">Visit Example</a>";
+					var expected = "[Visit Example](http://www.example.com)";
+
+					Assert.Equal(expected, _inlineConverter.Convert(html));
+				}
+
         [Fact]
         public void Should_not_convert_links_if_no_text_to_display()
         {

--- a/src/HtmlToMarkdown.Net/HtmlToMarkdownConverterEnd.cs
+++ b/src/HtmlToMarkdown.Net/HtmlToMarkdownConverterEnd.cs
@@ -91,9 +91,9 @@ namespace HtmlToMarkdown.Net
                             nodeStack.Push(localText);
                         }
 
-                        var title = attrs["title"];
-                        var trimmedTitle = title.Value.Trim();
-                        nodeStack.Push("](" + url + (false == string.IsNullOrWhiteSpace(title.Value) ? " \"" + Regex.Replace(trimmedTitle, @"\s+", " ") + "\"" : "") + ")");
+												var title = attrs.ContainsKey("title") && attrs["title"].Value != "" ? attrs["title"].Value : "";
+                        var trimmedTitle = title.Trim();
+                        nodeStack.Push("](" + url + (false == string.IsNullOrWhiteSpace(title) ? " \"" + Regex.Replace(trimmedTitle, @"\s+", " ") + "\"" : "") + ")");
 
                         if (HtmlToMarkdownConverterHelper.startsWith(nodeStack.Peek(), "!"))
                         {


### PR DESCRIPTION
Hi,

I just fixed an issue in your project relating to using HtmlToMarkdownConverter in inline mode. I'm using a javascript WYSIWYG content editor that produces html anchor tags that don't have title attributes. When I ran this through HtmlToMarkdownConverter I got a KeyNotFoundException. I've fixed up the line of code that tries to access the title attribute to check if it exists first (in the same way that a check is done on the href attribute).

Feel free to merge in this pull request to the main project if you are still maintaining it.

Commit message:
Fixed a bug where a KeyNotFoundException was thrown if parsing <a> tags with no title attribute in inline mode. Added unit test to cover this scenario.